### PR TITLE
Updates, refactoring and cleaning up.

### DIFF
--- a/BenchmarkView.pro
+++ b/BenchmarkView.pro
@@ -7,8 +7,12 @@ DEFINES += QT_DEPRECATED_WARNINGS
 
 SOURCES += \
         main.cpp \
-    benchmarkview.cpp
+    benchmarkview.cpp \
+    benchmarkmodel.cpp
 
 HEADERS += \
     benchmarkview.h \
     benchmarkmodel.h
+
+FORMS += \
+    benchmarkview.ui

--- a/benchmarkmodel.cpp
+++ b/benchmarkmodel.cpp
@@ -1,0 +1,20 @@
+#include "benchmarkmodel.h"
+
+static const int iterations = 1000;
+
+BenchmarkModel::BenchmarkModel(QObject * parent)
+    : QStandardItemModel(parent)
+{
+}
+
+void BenchmarkModel::dataChangeAll()
+{
+    for (qint32 i = 0; i < iterations; i++)
+        dataChanged(index(0, 0), index(rowCount() - 1, columnCount() - 1), { Qt::EditRole, Qt::DisplayRole });
+}
+
+void BenchmarkModel::dataChangeTop4()
+{
+    for (qint32 i = 0; i < iterations; i++)
+        dataChanged(index(0, 0), index(1, 1), {Qt::EditRole, Qt::DisplayRole});
+}

--- a/benchmarkmodel.h
+++ b/benchmarkmodel.h
@@ -1,13 +1,18 @@
 #ifndef BENCHMARKMODEL_H
 #define BENCHMARKMODEL_H
+
 #include <QStandardItemModel>
-class BenchmarkModel : public QStandardItemModel{
+
+class BenchmarkModel : public QStandardItemModel
+{
     Q_OBJECT
     Q_DISABLE_COPY(BenchmarkModel)
+
 public:
-    explicit BenchmarkModel(QObject* parent = Q_NULLPTR) : QStandardItemModel(parent){}
-public Q_SLOTS:
-    void dataChangeAll(){dataChanged(index(0,0),index(rowCount()-1,columnCount()-1),{Qt::EditRole, Qt::DisplayRole});}
-    void dataChangeTop4(){dataChanged(index(0,0),index(1,1),{Qt::EditRole, Qt::DisplayRole});}
+    explicit BenchmarkModel(QObject * parent = nullptr);
+
+public slots:
+    void dataChangeAll();
+    void dataChangeTop4();
 };
 #endif // BENCHMARKMODEL_H

--- a/benchmarkview.cpp
+++ b/benchmarkview.cpp
@@ -1,26 +1,57 @@
 #include "benchmarkview.h"
 #include <QHeaderView>
 #include <QAccessible>
-#include <private/qabstractitemview_p.h>
-#include <private/qtableview_p.h>
+//#include <private/qabstractitemview_p.h>
 #include <QElapsedTimer>
 #include <QApplication>
-QTableViewPrivate *BenchMarkView::d_func() { return reinterpret_cast<QTableViewPrivate *>(qGetPtrHelper(d_ptr)); }
 
-const QTableViewPrivate *BenchMarkView::d_func() const { return reinterpret_cast<const QTableViewPrivate *>(qGetPtrHelper(d_ptr)); }
+#include <private/qtableview_p.h>
 
-BenchMarkView::BenchMarkView(BenchMarkType typ, QWidget *parent):QTableView(parent),m_tpy(typ){}
-
-void BenchMarkView::dataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight, const QVector<int> &roles)
+class BenchmarkViewPrivate : public QTableViewPrivate
 {
-    QElapsedTimer elapsedCalc;
-    if(m_tpy==NoChange){
-        elapsedCalc.start();
-        QTableView::dataChanged(topLeft,bottomRight,roles);
-        QApplication::processEvents(QEventLoop::ExcludeUserInputEvents);
-        dataChangedElapsed(elapsedCalc.elapsed());
-        return;
+    Q_DECLARE_PUBLIC(BenchmarkView)
+
+    inline BenchmarkViewPrivate(BenchmarkView * q)
+        : QTableViewPrivate(), elapsed(0)
+    {
+        q_ptr = q;  // It is defined in QObjectData
     }
+
+    QElapsedTimer timer;
+    qint64 elapsed;
+};
+
+BenchmarkView::BenchmarkView(QWidget * parent)
+    : QTableView(*new BenchmarkViewPrivate(this), parent)
+{
+}
+
+void BenchmarkView::clearTimer()
+{
+    Q_D(BenchmarkView);
+    d->elapsed = 0;
+}
+
+void BenchmarkView::dataChanged(const QModelIndex & topLeft, const QModelIndex & bottomRight, const QVector<int> & roles)
+{
+    Q_D(BenchmarkView);
+    d->timer.start();
+    doUpdate(topLeft, bottomRight, roles);
+    QApplication::processEvents(QEventLoop::ExcludeUserInputEvents);
+    d->elapsed += d->timer.elapsed();
+
+    dataChangedElapsed(d->elapsed);
+}
+
+void BenchmarkView::doUpdate(const QModelIndex & topLeft, const QModelIndex & bottomRight, const QVector<int> & roles)
+{
+    QTableView::dataChanged(topLeft, bottomRight, roles);
+}
+
+void BenchmarkViewJoinRects::doUpdate(const QModelIndex & topLeft, const QModelIndex & bottomRight, const QVector<int> & roles)
+{
+    Q_UNUSED(roles);
+
     // Single item changed
     Q_D(QTableView);
     if (topLeft == bottomRight && topLeft.isValid()) {
@@ -39,44 +70,69 @@ void BenchMarkView::dataChanged(const QModelIndex &topLeft, const QModelIndex &b
     } else {
         d->updateEditorData(topLeft, bottomRight);
         if (isVisible() && !d->delayedPendingLayout)  {
-            if(m_tpy==JoinRects){
-                elapsedCalc.start();
-                const QRect viewportRect = viewport()->rect();
-                const QModelIndex parent = topLeft.parent();
-                const QRect cornerRect = visualRect(topLeft) | visualRect(bottomRight);
-                // If dirty is 1/4th or more of the viewport rect, just trigger a full update
-                const QRect cornerRectViewPort = cornerRect & viewportRect;
-                if(cornerRectViewPort.width() * cornerRectViewPort.height() * 4 > viewportRect.width() * viewportRect.height())  {
-                    viewport()->update();
-                }
-                else  { // Just fall back to iterating over the model indices
-                    QRect dirty(cornerRect);
-                    const int maxRow = bottomRight.row();
-                    for (int i = topLeft.row(); i < maxRow; ++i)  {
-                        const int maxColumn = bottomRight.column() - ((i==maxRow-1) ? 1:0);
-                        for (int j = topLeft.column()+ ((i==topLeft.row()) ? 1:0); j < maxColumn; ++j)  {
-                            dirty |= visualRect(d->model->index(i, j, parent));
-                        }
-                    }
-                    dirty &= viewportRect;
-                    if (!dirty.isEmpty())
-                        viewport()->update(dirty);
-                }
-                QApplication::processEvents(QEventLoop::ExcludeUserInputEvents);
-                dataChangedElapsed(elapsedCalc.elapsed());
+            const QRect viewportRect = viewport()->rect();
+            const QModelIndex parent = topLeft.parent();
+            const QRect cornerRect = visualRect(topLeft) | visualRect(bottomRight);
+            // If dirty is 1/4th or more of the viewport rect, just trigger a full update
+            const QRect cornerRectViewPort = cornerRect & viewportRect;
+            if(cornerRectViewPort.width() * cornerRectViewPort.height() * 4 > viewportRect.width() * viewportRect.height())  {
+                viewport()->update();
             }
-            else if(m_tpy==UpdateOnEach){
-                elapsedCalc.start();
+            else  { // Just fall back to iterating over the model indices
+                QRect dirty(cornerRect);
                 const int maxRow = bottomRight.row();
-                const QModelIndex parent = topLeft.parent();
                 for (int i = topLeft.row(); i < maxRow; ++i)  {
-                    const int maxColumn = bottomRight.column() - ((i==maxRow-1) ? 1:0);
-                    for (int j = topLeft.column()+ ((i==topLeft.row()) ? 1:0); j < maxColumn; ++j)  {
-                        viewport()->update(visualRect(model()->index(i, j, parent)));
+                    const int maxColumn = bottomRight.column() - ((i == maxRow -1 ) ? 1 : 0);
+                    for (int j = topLeft.column() + ((i == topLeft.row()) ? 1 : 0); j < maxColumn; ++j)  {
+                        dirty |= visualRect(d->model->index(i, j, parent));
                     }
                 }
-                QApplication::processEvents(QEventLoop::ExcludeUserInputEvents);
-                dataChangedElapsed(elapsedCalc.elapsed());
+                dirty &= viewportRect;
+                if (!dirty.isEmpty())
+                    viewport()->update(dirty);
+            }
+        }
+    }
+#ifndef QT_NO_ACCESSIBILITY
+    if (QAccessible::isActive()) {
+        QAccessibleTableModelChangeEvent accessibleEvent(this, QAccessibleTableModelChangeEvent::DataChanged);
+        accessibleEvent.setFirstRow(topLeft.row());
+        accessibleEvent.setFirstColumn(topLeft.column());
+        accessibleEvent.setLastRow(bottomRight.row());
+        accessibleEvent.setLastColumn(bottomRight.column());
+        QAccessible::updateAccessibility(&accessibleEvent);
+    }
+#endif
+    d->updateGeometry();
+}
+
+void BenchmarkViewUpdateEach::doUpdate(const QModelIndex & topLeft, const QModelIndex & bottomRight, const QVector<int> & roles)
+{
+    Q_UNUSED(roles);
+
+    // Single item changed
+    Q_D(QTableView);
+    if (topLeft == bottomRight && topLeft.isValid()) {
+        const QEditorInfo &editorInfo = d->editorForIndex(topLeft);
+        //we don't update the edit data if it is static
+        if (!editorInfo.isStatic && editorInfo.widget) {
+            QAbstractItemDelegate *delegate = d->delegateForIndex(topLeft);
+            if (delegate) {
+                delegate->setEditorData(editorInfo.widget.data(), topLeft);
+            }
+        }
+        if (isVisible() && !d->delayedPendingLayout) {
+            // otherwise the items will be update later anyway
+            update(topLeft);
+        }
+    } else {
+        d->updateEditorData(topLeft, bottomRight);
+        if (isVisible() && !d->delayedPendingLayout)  {
+            const QModelIndex parent = topLeft.parent();
+            for (int i = topLeft.row(), maxRow = bottomRight.row(); i < maxRow; ++i)  {
+                for (int j = topLeft.column(), maxColumn = bottomRight.column(); j < maxColumn; ++j)  {
+                    viewport()->update(visualRect(model()->index(i, j, parent)));
+                }
             }
         }
     }

--- a/benchmarkview.h
+++ b/benchmarkview.h
@@ -2,25 +2,54 @@
 #define BENCHMARKVIEW_H
 
 #include <QTableView>
-class BenchMarkView : public QTableView
+
+class BenchmarkViewPrivate;
+class BenchmarkView : public QTableView
 {
     Q_OBJECT
-    Q_DISABLE_COPY(BenchMarkView)
-    QTableViewPrivate* d_func();
-    const QTableViewPrivate* d_func() const;
+    Q_DISABLE_COPY(BenchmarkView)
+    Q_DECLARE_PRIVATE(BenchmarkView)
+
 public:
-    enum BenchMarkType{
-      NoChange
-      , JoinRects
-      , UpdateOnEach
-    };
-    explicit BenchMarkView(BenchMarkType typ,QWidget* parent = Q_NULLPTR);
-Q_SIGNALS:
+    explicit BenchmarkView(QWidget * parent = nullptr);
+
+signals:
     void dataChangedElapsed(qint64 mSec);
-protected Q_SLOTS:
-    void dataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight, const QVector<int> &roles);
-private:
-    const BenchMarkType m_tpy;
+
+public slots:
+    void clearTimer();
+
+protected:
+    virtual void doUpdate(const QModelIndex &, const QModelIndex &, const QVector<int> &);
+
+protected slots:
+    void dataChanged(const QModelIndex &, const QModelIndex &, const QVector<int> &) override;
+};
+
+class BenchmarkViewJoinRects : public BenchmarkView
+{
+    Q_OBJECT
+    Q_DISABLE_COPY(BenchmarkViewJoinRects)
+    Q_DECLARE_PRIVATE(BenchmarkView)
+
+public:
+    using BenchmarkView::BenchmarkView;
+
+protected:
+    void doUpdate(const QModelIndex &, const QModelIndex &, const QVector<int> &) override;
+};
+
+class BenchmarkViewUpdateEach : public BenchmarkView
+{
+    Q_OBJECT
+    Q_DISABLE_COPY(BenchmarkViewUpdateEach)
+    Q_DECLARE_PRIVATE(BenchmarkView)
+
+public:
+    using BenchmarkView::BenchmarkView;
+
+protected:
+    void doUpdate(const QModelIndex &, const QModelIndex &, const QVector<int> &) override;
 };
 
 #endif // BENCHMARKVIEW_H

--- a/benchmarkview.ui
+++ b/benchmarkview.ui
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Window</class>
+ <widget class="QWidget" name="Window">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>1116</width>
+    <height>561</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QGridLayout" name="gridLayout">
+     <item row="2" column="0">
+      <widget class="QLabel" name="defaultElapsed">
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="BenchmarkView" name="defaultView"/>
+     </item>
+     <item row="1" column="2">
+      <widget class="BenchmarkViewUpdateEach" name="updateCompressionView"/>
+     </item>
+     <item row="1" column="1">
+      <widget class="BenchmarkViewJoinRects" name="rectJoinView"/>
+     </item>
+     <item row="0" column="1">
+      <widget class="QLabel" name="label_2">
+       <property name="text">
+        <string>Manual rect join</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="0">
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Default implementation</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="2">
+      <widget class="QLabel" name="label_3">
+       <property name="text">
+        <string>Update event compression</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QLabel" name="rectJoinElapsed">
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="2">
+      <widget class="QLabel" name="updateCompressionElapsed">
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="update4ItemsButton">
+       <property name="text">
+        <string>Update 4 items</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="updateAllButton">
+       <property name="text">
+        <string>Update all</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>BenchmarkView</class>
+   <extends>QTableView</extends>
+   <header>benchmarkview.h</header>
+  </customwidget>
+  <customwidget>
+   <class>BenchmarkViewJoinRects</class>
+   <extends>QTableView</extends>
+   <header>benchmarkview.h</header>
+  </customwidget>
+  <customwidget>
+   <class>BenchmarkViewUpdateEach</class>
+   <extends>QTableView</extends>
+   <header>benchmarkview.h</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
Cleaned the code a little bit. Added an accumulated time and iteration count (1000 i think) for the updates.

**For "Update all":**
Manual rects joining and default implementation is on par (as expected).
The update compression fails miserably.

**For "Update top 4":**
Default implementation fails terribly. Manual rect join is a bit slower than the one relying on update events compression, but the difference is small - 8ms vs 0 ms for 1k `dataChanged()` calls.